### PR TITLE
docs: align first-prompt roadmap with current repo state

### DIFF
--- a/docs/codex-roadmap-first-prompt.md
+++ b/docs/codex-roadmap-first-prompt.md
@@ -1,7 +1,7 @@
 # Codex Roadmap Plan — First Prompt
 
 ## Purpose
-This roadmap translates the first product prompt into an execution plan Codex can follow inside the repository.
+This roadmap translates the first product prompt into a practical execution plan based on the **current state of this repository**.
 
 ## Source prompt scope
 Build **Virtual User** as a cross-platform meeting participant for:
@@ -14,8 +14,21 @@ Core architectural decision:
 - **one shared AI core**
 - **four meeting adapters**
 
+## Repository context analysis (as of March 29, 2026)
+### What exists today
+The repository currently contains documentation artifacts and planning notes:
+- roadmap and continuous documentation files under `docs/`
+- a minimal `README.md`
+- no implemented runtime packages yet (`core/`, `adapters/`, `media/`, `host_setup/`, `tests/` are not present)
+
+### Gap between plan and repository
+The roadmap assumes components that are not yet checked in. The immediate challenge is to create a clean scaffold and import structure before feature work begins.
+
+### Practical implication
+The next phase should prioritize establishing a runnable project skeleton with placeholder contracts so later work can be added incrementally without architecture drift.
+
 ## Product boundaries for v1
-Codex should treat the following as in scope for the first implementation cycle:
+Treat the following as in scope for the first implementation cycle:
 - join a meeting from a link
 - listen to audio
 - speak back when directly invoked
@@ -24,7 +37,7 @@ Codex should treat the following as in scope for the first implementation cycle:
 - expose human mute/stop controls
 - clearly disclose that the participant is AI
 
-Codex should treat the following as out of scope for v1:
+Treat the following as out of scope for v1:
 - autonomous interruptions
 - emotion inference
 - hidden participation
@@ -34,95 +47,126 @@ Codex should treat the following as out of scope for v1:
 ## Primary engineering principle
 Keep the shared core platform-agnostic. Platform-specific behavior must stay inside adapter modules.
 
-## Delivery order
-1. shared trigger and policy path
-2. session orchestrator
-3. media worker and TTS injection path
-4. first real adapter: Webex
-5. host-level audio plumbing for Linux
-6. hardening and smoke tests
-7. CI baseline
-8. additional adapters later
+## Updated delivery sequence for the current repository
+1. repository bootstrap and package scaffolding
+2. shared trigger/policy/session core contracts
+3. media contracts and local TTS/injection abstraction
+4. first functional adapter track (Webex) with dry-run mode
+5. Linux host audio setup scripts and validation flow
+6. smoke tests and lightweight CI baseline
+7. incremental adapters for Teams/Zoom/Meet
 
-## Phase 1 — Shared core stabilization
-### Goal
-Make the core invocation and response path reliable before adding more platform complexity.
+## Execution plan
 
-### Codex tasks
-- preserve `TriggerRouter` as the single entry point for push-to-talk, wake-word, and chat-trigger events
-- preserve `PolicyEngine` as the single approval gate
-- preserve `SessionOrchestrator` as the single response pipeline owner
-- keep output fallback behavior: audio first, chat fallback second
-- avoid platform-specific logic in `core/`
+### Phase 0 — Repository bootstrap (new)
+#### Goal
+Create a reliable baseline so the project is importable, testable, and safe for incremental implementation.
 
-### Acceptance criteria
+#### Tasks
+- add Python package structure:
+  - `core/`
+  - `adapters/`
+  - `media/`
+  - `host_setup/linux/`
+  - `tests/`
+- add `__init__.py` files and consistent import paths
+- add base config model (`config.py` or `settings.py`)
+- add starter CLI entrypoint for local dry-run execution
+- add `.gitignore`, formatting/lint placeholders, and dependency manifest
+
+#### Acceptance criteria
+- `python -m compileall` passes
+- imports resolve from repository root
+- basic CLI dry-run command executes
+
+### Phase 1 — Shared core stabilization
+#### Goal
+Make the invocation and response path reliable before adapter complexity increases.
+
+#### Tasks
+- implement `TriggerRouter` as the single entry for push-to-talk, wake-word, and chat-trigger events
+- implement `PolicyEngine` as the approval gate
+- implement `SessionOrchestrator` as the response pipeline owner
+- enforce output fallback: audio first, chat fallback second
+- keep `core/` free from platform-specific branches
+
+#### Acceptance criteria
 - all trigger types route into one pipeline
 - rejected events are logged
 - successful responses are logged
 - chat fallback works when audio injection fails
 
-## Phase 2 — Media path hardening
-### Goal
-Keep the media path runnable locally and easy to upgrade later.
+### Phase 2 — Media path hardening
+#### Goal
+Keep the media path locally runnable and provider-agnostic.
 
-### Codex tasks
-- maintain `media/contracts.py` as the stable contract boundary
-- keep `create_tts_provider()` configurable
-- keep `create_injector()` configurable
+#### Tasks
+- define and preserve `media/contracts.py` as the stable boundary
+- implement configurable factories:
+  - `create_tts_provider()`
+  - `create_injector()`
 - support local file-spool and FFmpeg injection modes
-- keep device detection separate from actual injection
+- keep device detection separate from injection execution
 
-### Acceptance criteria
+#### Acceptance criteria
 - local synthesis works without cloud credentials
-- FFmpeg path accepts explicit or auto-detected targets
-- device detection can generate a machine-readable report
+- FFmpeg mode accepts explicit or auto-detected targets
+- device detection emits a machine-readable report
 
-## Phase 3 — Webex implementation track
-### Goal
-Advance the first real platform adapter without destabilizing the shared core.
+### Phase 3 — Webex implementation track
+#### Goal
+Implement the first real adapter without destabilizing shared core behavior.
 
-### Codex tasks
-- treat `adapters/webex_meeting.py` as the first real adapter target
-- keep dry-run support for local development
-- isolate join, leave, chat, mute, unmute, reconnect, and participant-state logic inside the adapter
-- connect `send_audio()` to the media worker contract
-- leave unsupported or credential-dependent operations behind explicit placeholders until real secrets are available
+#### Tasks
+- implement `adapters/webex_meeting.py` with dry-run support
+- isolate join, leave, chat, mute/unmute, reconnect, and participant-state logic in adapter scope
+- connect `send_audio()` to media worker contracts
+- keep credential-dependent operations behind explicit TODO/config gates
 
-### Acceptance criteria
-- adapter can run in dry-run mode
-- adapter can call the media worker
-- adapter can preserve chat fallback behavior
-- adapter exposes participant/session state for diagnostics
+#### Acceptance criteria
+- dry-run mode functions locally
+- adapter invokes media worker contract
+- chat fallback remains available
+- adapter exposes diagnostics for participant/session state
 
-## Phase 4 — Linux host audio setup
-### Goal
-Provide a reproducible path from generated speech to a selectable host microphone source.
+### Phase 4 — Linux host audio setup
+#### Goal
+Provide reproducible host routing from generated speech to virtual microphone source.
 
-### Codex tasks
-- maintain the Linux host setup package under `host_setup/linux`
-- keep create, validate, and destroy scripts separate
+#### Tasks
+- keep setup package under `host_setup/linux/`
+- provide separate scripts for create/validate/destroy workflows
 - keep environment-driven configuration in `host_audio.env.example`
-- keep validation artifacts and logs under runtime data paths
+- persist validation logs and artifacts in runtime paths
 
-### Acceptance criteria
-- create script builds a virtual sink/source pair on supported hosts
-- validate script produces a captured WAV and an analysis JSON
+#### Acceptance criteria
+- create script builds virtual sink/source pair on supported hosts
+- validate script outputs captured WAV + analysis JSON
 - destroy script removes created modules cleanly
 
-## Phase 5 — Quality gate
-### Goal
-Protect the POC from regression while it evolves.
+### Phase 5 — Quality gate
+#### Goal
+Prevent regressions while implementation accelerates.
 
-### Codex tasks
-- preserve smoke tests under `tests/test_smoke.py`
-- preserve import/package hygiene
-- extend CI without making it heavy too early
-- prefer small, testable increments
+#### Tasks
+- add and preserve smoke tests under `tests/test_smoke.py`
+- validate package/import hygiene
+- add lightweight CI for compile + smoke runs
+- enforce small, testable increments
 
-### Acceptance criteria
+#### Acceptance criteria
 - compile step passes
 - smoke tests pass
 - CI remains lightweight and fast
+
+## Immediate next steps (actionable, repo-aware)
+1. **Create scaffolding PR** with package directories, base contracts, and placeholder classes.
+2. **Add minimal runnable path**: one CLI command that accepts a trigger and prints/logs orchestrator flow.
+3. **Introduce smoke tests** that validate imports and a dry-run response pipeline.
+4. **Implement media contract stubs** with local no-cloud fallback.
+5. **Implement Webex dry-run adapter** wired to the shared orchestrator.
+6. **Add Linux host setup placeholders** for create/validate/destroy scripts with clear TODO markers.
+7. **Document every increment** in `docs/continuous-documentation.md` after each PR.
 
 ## Codex working rules
 - do not rewrite architecture unless a concrete defect requires it
@@ -131,15 +175,8 @@ Protect the POC from regression while it evolves.
 - do not add autonomous or deceptive AI behavior to v1
 - maintain explicit AI disclosure and human override assumptions
 
-## Immediate next tasks for Codex
-1. complete missing repository import in batches
-2. normalize package imports if needed for repository execution
-3. add remaining POC files that are still only local
-4. extend Webex adapter toward real join and chat integration behind config gates
-5. prepare the next adapter after Webex only when smoke tests stay green
-
 ## Definition of success for the first prompt
-Codex succeeds if the repository becomes a clean, runnable, documented POC that demonstrates:
+Success means the repository becomes a clean, runnable, documented POC demonstrating:
 - unified invocation
 - policy-controlled behavior
 - media output path

--- a/docs/repository-description.md
+++ b/docs/repository-description.md
@@ -1,14 +1,52 @@
 # Repository Description
 
-Virtual User AI is a cross-platform meeting participant project for Microsoft Teams, Zoom, Google Meet, and Cisco Webex.
+## What this repository is
+**Virtual User AI** is a planning-first repository for building an AI meeting participant that can operate across:
+- Microsoft Teams
+- Zoom
+- Google Meet
+- Cisco Webex
 
-The repository is intended to contain:
-- product and project documentation
-- the continuous documentation log
-- a trigger-based proof of concept
-- adapter work for real meeting platforms
-- a media worker and audio injection path
-- Linux host setup tooling for virtual microphone routing
-- tests and CI baseline artifacts
+The intended architecture is one shared, platform-agnostic AI core with separate platform adapters.
 
-The design principle is one shared AI core with multiple platform adapters.
+## Current state
+At present, this repository is primarily documentation-driven and defines implementation direction, scope boundaries, and phased execution plans.
+
+Current content includes:
+- roadmap and phased implementation guidance
+- continuous project documentation log
+- baseline repository metadata (`README.md`, `LICENSE`)
+
+## Intended v1 capabilities
+The v1 product direction in this repository targets:
+- joining meetings from links
+- listening to audio context
+- speaking when explicitly invoked
+- chat fallback when audio output fails
+- maintaining meeting memory/state
+- honoring human mute/stop override controls
+- explicit AI disclosure during participation
+
+## Intended v1 non-goals
+Out of scope for v1:
+- autonomous interruption behavior
+- emotion inference
+- hidden/deceptive participation
+- video/avatar presence
+- persuasion/negotiation automation
+
+## Planned project structure (target)
+As implementation is added, the repository is expected to include:
+- `core/` for trigger routing, policy, and orchestration
+- `adapters/` for platform-specific integrations
+- `media/` for TTS and host audio injection contracts
+- `host_setup/linux/` for virtual audio routing scripts
+- `tests/` for smoke and regression checks
+- CI workflows for compile and smoke validation
+
+## Engineering principles
+- Keep shared logic platform-agnostic.
+- Isolate provider/platform details behind contracts.
+- Prefer incremental, testable changes.
+- Keep docs synchronized with code.
+- Preserve explicit human control and AI transparency.


### PR DESCRIPTION
### Motivation
- The existing roadmap assumed implementation components that are not yet present in the repository, so the plan needed to be made actionable from the current docs-only baseline.
- Provide an explicit Phase 0 (bootstrap) so contributors can create a runnable scaffold and avoid architecture drift as features are added.
- Clarify v1 goals, non-goals, and engineering principles so future implementation work stays aligned with project constraints.

### Description
- Updated `docs/codex-roadmap-first-prompt.md` to include a repository-context analysis, a new Phase 0 bootstrap plan, a revised delivery sequence, a concrete execution plan across phases, and an "Immediate next steps" checklist aimed at repository-aware work.
- Added `docs/repository-description.md` as a full repository description covering what the repo is, current state, intended v1 capabilities and non-goals, planned project structure, and engineering principles.
- Reworked phase wording, acceptance criteria, and tasks for clarity and consistency to make the roadmap executable from the current repository state.
- Kept the changes documentation-focused and left implementation scaffolding and tests to follow in subsequent PRs.

### Testing
- Ran `git diff --check` and it returned no issues.
- No runtime or unit tests were added in this PR; smoke tests and compile checks are listed as immediate next steps to be added in follow-up changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c891846dec832dbe9b03784d416f88)