### PR TITLE
docs: update import batch status in README and continuous documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # virtual-user-ai
+
+Virtual User AI is a cross-platform meeting participant project targeting Teams, Zoom, Google Meet, and Webex, based on one shared AI core plus platform adapters.
+
+## Repository status (import batch update)
+
+### What was imported
+- Core project docs: `docs/repository-description.md` and `docs/continuous-documentation.md`
+- Roadmap docs for execution planning: `docs/codex-roadmap-first-prompt.md` and `docs/continuous-documentation-entry-10-codex-roadmap.md`
+
+### What remains missing
+- implementation code for core orchestration, adapters, media pipeline, and Linux host setup
+- smoke tests and CI wiring referenced in planning docs
+- executable entrypoints for local run and validation
+
+### What is runnable
+- documentation review and planning workflow only
+
+### What is still placeholder-only
+- all described runtime modules and integration behavior are placeholders at this stage and have not yet been imported as code

--- a/docs/continuous-documentation.md
+++ b/docs/continuous-documentation.md
@@ -51,3 +51,18 @@ A lightweight CI baseline was defined to run byte-compilation and smoke tests fo
 ## Entry 9 — Current repository import status
 The repository now contains an initial repository description and a continuous documentation file.
 More project files should be added incrementally to avoid losing structure or overwriting existing contents.
+
+## Entry 10 — Codex roadmap import batch
+### What was imported
+- `docs/codex-roadmap-first-prompt.md` was imported to capture the implementation roadmap and acceptance criteria.
+- `docs/continuous-documentation-entry-10-codex-roadmap.md` was imported as a standalone log entry for roadmap rationale.
+
+### What remains missing
+- runnable source code for core modules, meeting adapters, media pipeline, host setup scripts, and tests described in the roadmap
+- CI configuration and package structure that match the documented architecture
+
+### What is runnable
+- documentation-only repository navigation and review
+
+### What is still placeholder-only
+- all architecture components referenced in documentation (TriggerRouter, PolicyEngine, SessionOrchestrator, adapters, media worker, Linux host setup, smoke tests) remain documentation placeholders until code is imported


### PR DESCRIPTION
### Motivation
- Record the results of the recent documentation import batch and make the repository status visible to readers and contributors.
- Keep the top-level `README.md` synchronized with the continuous documentation log so import status is discoverable without digging through `docs/`.

### Description
- Added `Entry 10 — Codex roadmap import batch` to `docs/continuous-documentation.md` and populated the required categories: what was imported, what remains missing, what is runnable, and what is still placeholder-only.
- Updated `README.md` to include a `Repository status (import batch update)` section that mirrors the same four categories and current repo-state details.
- Committed the documentation updates to the current branch.

### Testing
- Ran `git status --short` to verify staged changes and the command completed successfully.
- Performed the commit via `git commit` and verified the new HEAD with `git rev-parse --short HEAD`, which succeeded.
- Inspected the updated files with `nl -ba README.md` and `nl -ba docs/continuous-documentation.md` to confirm the content was written as intended, and the inspection commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e7f4fc60832d9098ff371bd362b7)