### PR TITLE
Add Webex and Linux host-setup tracks after shared adapter layers

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -1,0 +1,13 @@
+"""Adapter package."""
+
+from adapters.base import JoinOptions, MeetingAdapter, bootstrap_layers
+from adapters.mock_meeting import MockMeetingAdapter
+from adapters.webex_meeting import WebexMeetingAdapter
+
+__all__ = [
+    "JoinOptions",
+    "MeetingAdapter",
+    "MockMeetingAdapter",
+    "WebexMeetingAdapter",
+    "bootstrap_layers",
+]

--- a/adapters/base.py
+++ b/adapters/base.py
@@ -1,0 +1,61 @@
+"""Shared meeting adapter interfaces and common layers.
+
+This module intentionally exposes the shared ``core`` and ``media`` layers first.
+Platform- or provider-specific tracks (for example Webex) are imported only after
+these common layers are initialized.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+
+
+class AdapterLayer(str, Enum):
+    """Order-sensitive layers used by the runtime bootstrap path."""
+
+    CORE = "core"
+    MEDIA = "media"
+    WEBEX = "webex"
+    HOST_SETUP_LINUX = "host_setup_linux"
+
+
+SHARED_LAYER_ORDER: tuple[AdapterLayer, ...] = (
+    AdapterLayer.CORE,
+    AdapterLayer.MEDIA,
+)
+
+OPTIONAL_LAYER_ORDER: tuple[AdapterLayer, ...] = (
+    AdapterLayer.WEBEX,
+    AdapterLayer.HOST_SETUP_LINUX,
+)
+
+
+@dataclass(slots=True)
+class JoinOptions:
+    """Runtime options for joining a meeting."""
+
+    meeting_url: str
+    display_name: str = "Virtual User"
+    dry_run: bool = True
+
+
+class MeetingAdapter(ABC):
+    """Abstract base for all provider adapters."""
+
+    provider: str
+
+    @abstractmethod
+    def join(self, options: JoinOptions) -> dict[str, str]:
+        """Join (or simulate joining) a meeting and return run metadata."""
+
+
+def bootstrap_layers() -> list[AdapterLayer]:
+    """Return the expected runtime layer import order."""
+
+    return [*SHARED_LAYER_ORDER, *OPTIONAL_LAYER_ORDER]
+
+
+# Import provider-specific tracks only after shared layers are defined.
+from adapters.webex_meeting import WebexMeetingAdapter  # noqa: E402

--- a/adapters/mock_meeting.py
+++ b/adapters/mock_meeting.py
@@ -1,0 +1,18 @@
+"""Mock meeting adapter used for tests and local dry runs."""
+
+from __future__ import annotations
+
+from adapters.base import JoinOptions, MeetingAdapter
+
+
+class MockMeetingAdapter(MeetingAdapter):
+    provider = "mock"
+
+    def join(self, options: JoinOptions) -> dict[str, str]:
+        status = "simulated" if options.dry_run else "connected"
+        return {
+            "provider": self.provider,
+            "status": status,
+            "meeting_url": options.meeting_url,
+            "display_name": options.display_name,
+        }

--- a/adapters/webex_meeting.py
+++ b/adapters/webex_meeting.py
@@ -1,0 +1,30 @@
+"""Webex meeting adapter.
+
+The implementation remains intentionally placeholder-friendly while the full
+Webex automation surface is still under development.
+"""
+
+from __future__ import annotations
+
+from adapters.base import JoinOptions, MeetingAdapter
+
+
+class WebexMeetingAdapter(MeetingAdapter):
+    provider = "webex"
+
+    def join(self, options: JoinOptions) -> dict[str, str]:
+        if options.dry_run:
+            return {
+                "provider": self.provider,
+                "status": "dry-run",
+                "detail": "Webex adapter placeholder path executed.",
+                "meeting_url": options.meeting_url,
+            }
+
+        # Placeholder: concrete browser/device automation is wired later.
+        return {
+            "provider": self.provider,
+            "status": "not-implemented",
+            "detail": "Live Webex join flow is not implemented yet.",
+            "meeting_url": options.meeting_url,
+        }

--- a/host_setup/__init__.py
+++ b/host_setup/__init__.py
@@ -1,0 +1,1 @@
+"""Host setup package."""

--- a/host_setup/linux/__init__.py
+++ b/host_setup/linux/__init__.py
@@ -1,0 +1,8 @@
+"""Linux host setup track.
+
+Imported after shared adapter core/media layers to keep optional setup isolated.
+"""
+
+from .setup import setup_linux_host
+
+__all__ = ["setup_linux_host"]

--- a/host_setup/linux/setup.py
+++ b/host_setup/linux/setup.py
@@ -1,0 +1,22 @@
+"""Linux host setup helpers."""
+
+from __future__ import annotations
+
+
+def setup_linux_host(*, dry_run: bool = True) -> dict[str, str]:
+    """Prepare Linux host dependencies.
+
+    Keeps dry-run support for CI and local validation environments.
+    """
+
+    if dry_run:
+        return {
+            "status": "dry-run",
+            "detail": "Linux host setup skipped (dry run).",
+        }
+
+    # Placeholder for package install / service checks.
+    return {
+        "status": "not-implemented",
+        "detail": "Linux host setup steps are not implemented yet.",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,31 @@
+from adapters.base import AdapterLayer, JoinOptions, bootstrap_layers
+from adapters.mock_meeting import MockMeetingAdapter
+from adapters.webex_meeting import WebexMeetingAdapter
+from host_setup.linux import setup_linux_host
+
+
+def test_layer_bootstrap_order_keeps_webex_and_linux_after_shared_layers():
+    assert bootstrap_layers() == [
+        AdapterLayer.CORE,
+        AdapterLayer.MEDIA,
+        AdapterLayer.WEBEX,
+        AdapterLayer.HOST_SETUP_LINUX,
+    ]
+
+
+def test_mock_adapter_dry_run_stays_available():
+    adapter = MockMeetingAdapter()
+    result = adapter.join(JoinOptions(meeting_url="https://example.invalid", dry_run=True))
+    assert result["status"] == "simulated"
+
+
+def test_webex_adapter_allows_placeholder_dry_run():
+    adapter = WebexMeetingAdapter()
+    result = adapter.join(JoinOptions(meeting_url="https://webex.com/meet/demo", dry_run=True))
+    assert result["provider"] == "webex"
+    assert result["status"] == "dry-run"
+
+
+def test_linux_host_setup_dry_run_stays_available():
+    result = setup_linux_host(dry_run=True)
+    assert result["status"] == "dry-run"


### PR DESCRIPTION
### Motivation
- Ensure shared `core` and `media` adapter layers are defined and loaded before optional platform/provider tracks and host setup to keep optional pieces isolated.
- Provide initial Webex and Linux host-setup scaffolding that preserves `dry-run` capability for CI and local validation while full automation is implemented later.

### Description
- Added `adapters/base.py` with `AdapterLayer`, `SHARED_LAYER_ORDER`, `OPTIONAL_LAYER_ORDER`, `JoinOptions`, `MeetingAdapter`, and `bootstrap_layers()` and deferred provider import to keep shared layers first.
- Added `adapters/mock_meeting.py` implementing `MockMeetingAdapter` that simulates joins in dry-run mode and `adapters/webex_meeting.py` implementing a placeholder-friendly `WebexMeetingAdapter` that supports `dry-run` and reports `not-implemented` for live joins.
- Added `host_setup/linux/setup.py` and `host_setup/linux/__init__.py` exposing `setup_linux_host()` with `dry_run` support.
- Added `tests/test_smoke.py` to assert bootstrap layer order and dry-run behavior for mock, Webex, and Linux setup, and added `tests/conftest.py` to ensure repository-root imports under `pytest`.

### Testing
- Ran `pytest -q` initially which failed during collection due to import path resolution (`ModuleNotFoundError`) while developing tests.
- Added `tests/conftest.py` to adjust `sys.path` and reran `pytest -q`, which passed with `4 passed in 0.04s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e754a128832d9618b2781ea31400)