### PR TITLE
Add media and service scaffolding for TTS, device detection, and audio injection

### DIFF
--- a/config/media.example.json
+++ b/config/media.example.json
@@ -1,0 +1,14 @@
+{
+  "tts": {
+    "provider": "mock",
+    "default_voice": "alloy"
+  },
+  "injector": {
+    "injector": "logging",
+    "target_device_id": null
+  },
+  "device_detection": {
+    "enabled": false,
+    "notes": "Host audio device enumeration/routing is environment-dependent."
+  }
+}

--- a/config/media.openai.example.json
+++ b/config/media.openai.example.json
@@ -1,0 +1,14 @@
+{
+  "tts": {
+    "provider": "openai",
+    "model": "gpt-4o-mini-tts",
+    "default_voice": "alloy"
+  },
+  "injector": {
+    "injector": "noop"
+  },
+  "device_detection": {
+    "enabled": false,
+    "notes": "Wire detector implementation per deployment OS/runtime."
+  }
+}

--- a/media/contracts.py
+++ b/media/contracts.py
@@ -1,0 +1,68 @@
+"""Contracts for media input/output components.
+
+This module intentionally separates:
+- TTS provider concerns
+- Device detection concerns
+- Audio injection concerns
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+
+@dataclass(frozen=True)
+class TTSRequest:
+    """Normalized request for generating speech."""
+
+    text: str
+    voice: str | None = None
+    sample_rate_hz: int = 24_000
+    format: str = "pcm_s16le"
+
+
+@dataclass(frozen=True)
+class SynthesizedAudio:
+    """TTS output payload."""
+
+    audio_bytes: bytes
+    sample_rate_hz: int
+    channels: int
+    encoding: str
+
+
+class TTSProvider(Protocol):
+    """Service contract for text-to-speech providers."""
+
+    async def synthesize(self, request: TTSRequest) -> SynthesizedAudio:
+        """Generate audio for the provided request."""
+
+
+@dataclass(frozen=True)
+class AudioDevice:
+    """Represents a discovered system audio device."""
+
+    id: str
+    name: str
+    is_input: bool
+    is_output: bool
+    is_default: bool = False
+    metadata: Mapping[str, Any] | None = None
+
+
+class DeviceDetector(Protocol):
+    """Discovery-only contract for locating audio devices."""
+
+    def list_devices(self) -> list[AudioDevice]:
+        """Return all known audio devices."""
+
+
+class AudioInjector(Protocol):
+    """Injection-only contract for writing audio into a target device/path."""
+
+    def inject(self, audio: SynthesizedAudio, *, target_device_id: str | None = None) -> None:
+        """Inject synthesized audio to a selected path.
+
+        Note: successful host-level routing can be environment dependent.
+        """

--- a/media/device_detection.py
+++ b/media/device_detection.py
@@ -1,0 +1,24 @@
+"""Device detection is intentionally separate from audio injection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .contracts import AudioDevice, DeviceDetector
+
+
+@dataclass(frozen=True)
+class StaticDeviceDetector(DeviceDetector):
+    """Simple detector backed by static configured devices."""
+
+    devices: list[AudioDevice]
+
+    def list_devices(self) -> list[AudioDevice]:
+        return list(self.devices)
+
+
+class EmptyDeviceDetector(DeviceDetector):
+    """Detector used in environments where host devices are not enumerable."""
+
+    def list_devices(self) -> list[AudioDevice]:
+        return []

--- a/media/tts_provider.py
+++ b/media/tts_provider.py
@@ -1,0 +1,80 @@
+"""Configurable TTS provider factory and provider implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .contracts import SynthesizedAudio, TTSProvider, TTSRequest
+
+
+@dataclass(frozen=True)
+class TTSProviderConfig:
+    """Configuration for selecting a provider implementation."""
+
+    provider: str = "mock"
+    default_voice: str | None = None
+    model: str | None = None
+    options: Mapping[str, Any] | None = None
+
+
+class MockTTSProvider:
+    """Deterministic local mock provider for development/testing."""
+
+    def __init__(self, *, default_voice: str | None = None) -> None:
+        self._default_voice = default_voice or "alloy"
+
+    async def synthesize(self, request: TTSRequest) -> SynthesizedAudio:
+        voice = request.voice or self._default_voice
+        # Placeholder payload - caller can still exercise pipeline end-to-end.
+        payload = f"MOCK_TTS|voice={voice}|text={request.text}".encode("utf-8")
+        return SynthesizedAudio(
+            audio_bytes=payload,
+            sample_rate_hz=request.sample_rate_hz,
+            channels=1,
+            encoding=request.format,
+        )
+
+
+class OpenAITTSProvider:
+    """Example OpenAI-backed provider placeholder.
+
+    This intentionally does not hard-wire SDK/network behavior in this environment.
+    """
+
+    def __init__(self, *, model: str | None = None, default_voice: str | None = None) -> None:
+        self._model = model or "gpt-4o-mini-tts"
+        self._default_voice = default_voice or "alloy"
+
+    async def synthesize(self, request: TTSRequest) -> SynthesizedAudio:
+        raise NotImplementedError(
+            "OpenAI TTS integration is not enabled in this environment. "
+            "Use provider='mock' or wire SDK calls for your deployment."
+        )
+
+
+def create_tts_provider(config: TTSProviderConfig | Mapping[str, Any] | None = None) -> TTSProvider:
+    """Create a TTS provider from config.
+
+    Kept configurable by accepting either a typed config object or raw mapping.
+    """
+
+    if config is None:
+        resolved = TTSProviderConfig()
+    elif isinstance(config, TTSProviderConfig):
+        resolved = config
+    else:
+        resolved = TTSProviderConfig(
+            provider=str(config.get("provider", "mock")),
+            default_voice=config.get("default_voice"),
+            model=config.get("model"),
+            options=config.get("options"),
+        )
+
+    provider = resolved.provider.strip().lower()
+    if provider == "mock":
+        return MockTTSProvider(default_voice=resolved.default_voice)
+    if provider in {"openai", "openai_tts"}:
+        return OpenAITTSProvider(model=resolved.model, default_voice=resolved.default_voice)
+
+    raise ValueError(f"Unsupported TTS provider: {resolved.provider}")

--- a/media/virtual_mic.py
+++ b/media/virtual_mic.py
@@ -1,0 +1,69 @@
+"""Virtual microphone injection abstractions and factory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .contracts import AudioInjector, SynthesizedAudio
+
+
+@dataclass(frozen=True)
+class InjectorConfig:
+    """Configuration for selecting an injection backend."""
+
+    injector: str = "noop"
+    target_device_id: str | None = None
+    options: Mapping[str, Any] | None = None
+
+
+class NoopAudioInjector:
+    """No-op injector used in non-routable or test environments."""
+
+    def __init__(self, *, target_device_id: str | None = None) -> None:
+        self._target_device_id = target_device_id
+
+    def inject(self, audio: SynthesizedAudio, *, target_device_id: str | None = None) -> None:
+        _ = (audio, target_device_id or self._target_device_id)
+        # Intentionally no host audio routing.
+
+
+class LoggingAudioInjector:
+    """Injector that logs intent; useful when host routing is environment dependent."""
+
+    def __init__(self, *, target_device_id: str | None = None) -> None:
+        self._target_device_id = target_device_id
+
+    def inject(self, audio: SynthesizedAudio, *, target_device_id: str | None = None) -> None:
+        effective_target = target_device_id or self._target_device_id or "<unspecified>"
+        print(
+            "[virtual_mic] inject requested "
+            f"bytes={len(audio.audio_bytes)} sample_rate={audio.sample_rate_hz} "
+            f"channels={audio.channels} encoding={audio.encoding} target={effective_target}"
+        )
+
+
+def create_injector(config: InjectorConfig | Mapping[str, Any] | None = None) -> AudioInjector:
+    """Create an audio injector from config.
+
+    Kept configurable by accepting either a typed config object or raw mapping.
+    """
+
+    if config is None:
+        resolved = InjectorConfig()
+    elif isinstance(config, InjectorConfig):
+        resolved = config
+    else:
+        resolved = InjectorConfig(
+            injector=str(config.get("injector", "noop")),
+            target_device_id=config.get("target_device_id"),
+            options=config.get("options"),
+        )
+
+    injector = resolved.injector.strip().lower()
+    if injector == "noop":
+        return NoopAudioInjector(target_device_id=resolved.target_device_id)
+    if injector == "logging":
+        return LoggingAudioInjector(target_device_id=resolved.target_device_id)
+
+    raise ValueError(f"Unsupported injector: {resolved.injector}")

--- a/services/media_worker_service.py
+++ b/services/media_worker_service.py
@@ -1,0 +1,55 @@
+"""Media worker orchestration for detection, synthesis, and injection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from media.contracts import AudioInjector, DeviceDetector, TTSRequest
+from media.device_detection import EmptyDeviceDetector
+from media.tts_provider import create_tts_provider
+from media.virtual_mic import create_injector
+
+
+@dataclass
+class MediaWorkerService:
+    """Coordinates TTS generation and optional injection."""
+
+    tts_provider: Any
+    injector: AudioInjector
+    detector: DeviceDetector
+
+    async def speak(
+        self,
+        text: str,
+        *,
+        voice: str | None = None,
+        target_device_id: str | None = None,
+        inject: bool = True,
+    ) -> None:
+        request = TTSRequest(text=text, voice=voice)
+        audio = await self.tts_provider.synthesize(request)
+
+        if inject:
+            self.injector.inject(audio, target_device_id=target_device_id)
+
+
+def create_media_worker_service(config: Mapping[str, Any] | None = None) -> MediaWorkerService:
+    """Build MediaWorkerService from nested config.
+
+    Expected shape:
+    {
+      "tts": {...},
+      "injector": {...},
+      "device_detection": {"enabled": true}
+    }
+    """
+
+    config = config or {}
+    tts = create_tts_provider(config.get("tts"))
+    injector = create_injector(config.get("injector"))
+
+    # Keep detection separate from injection; no implicit coupling here.
+    detector = EmptyDeviceDetector()
+
+    return MediaWorkerService(tts_provider=tts, injector=injector, detector=detector)


### PR DESCRIPTION
### Motivation
- Provide a small, explicit media layer with contracts and factories to support TTS generation and optional injection while keeping platform-dependent routing explicit.
- Enable composing TTS provider, device detection, and injection in a single service so callers can exercise end-to-end flows in development and wire real implementations per deployment.

### Description
- Add `media/contracts.py` with `TTSRequest`, `SynthesizedAudio`, `TTSProvider`, `AudioDevice`, `DeviceDetector`, and `AudioInjector` contracts to separate concerns.
- Add `media/tts_provider.py` and `create_tts_provider` with a `MockTTSProvider` implementation and an `OpenAITTSProvider` placeholder that raises `NotImplementedError` while keeping config-driven construction.`
- Add `media/virtual_mic.py` and `create_injector` with `NoopAudioInjector` and `LoggingAudioInjector` backends and configurable `InjectorConfig` to avoid environment-dependent routing assumptions.
- Add `media/device_detection.py` with `StaticDeviceDetector` and `EmptyDeviceDetector` to keep detection decoupled from injection, plus `services/media_worker_service.py` which composes provider + injector + detector into `MediaWorkerService`.
- Add example configs `config/media.example.json` and `config/media.openai.example.json` demonstrating mock and OpenAI-style setups while documenting that host audio routing/enumeration is environment-dependent.

### Testing
- Ran `python -m compileall media services` and compilation succeeded for the new modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8e64b6f34832da8ffdeed90ba5f45)