### PR TITLE
Add GitHub Project #2 setup workflow, CLI script, documentation, and tests

### DIFF
--- a/.github/workflows/setup-project2.yml
+++ b/.github/workflows/setup-project2.yml
@@ -1,0 +1,190 @@
+name: Setup GitHub Project #2
+
+on:
+  workflow_dispatch:
+    inputs:
+      owner:
+        description: "GitHub user/org that owns Project #2"
+        required: false
+        default: "intiequals1"
+      project_number:
+        description: "Project number"
+        required: false
+        default: "2"
+
+jobs:
+  seed-project:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      OWNER: ${{ inputs.owner }}
+      PROJECT_NUMBER: ${{ inputs.project_number }}
+      REPO: ${{ github.event.repository.name }}
+    steps:
+      - name: Validate token
+        if: ${{ secrets.PROJECT_SETUP_TOKEN == '' }}
+        run: |
+          echo "Missing secret PROJECT_SETUP_TOKEN."
+          echo "Add a PAT with repo + project scopes as PROJECT_SETUP_TOKEN in repository secrets."
+          exit 1
+
+      - name: Seed labels, issues, and project items
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_SETUP_TOKEN }}
+          script: |
+            const owner = process.env.OWNER || 'intiequals1';
+            const repo = process.env.REPO;
+            const projectNumber = Number(process.env.PROJECT_NUMBER || '2');
+            const projectDescription = 'Cross-platform AI Virtual User: shared AI core with platform adapters (Webex first), Linux host audio path, smoke tests, and CI baseline.';
+
+            const labels = [
+              { name: 'priority:P0', color: 'B60205', description: 'Highest priority' },
+              { name: 'priority:P1', color: 'D93F0B', description: 'High priority' },
+              { name: 'priority:P2', color: 'FBCA04', description: 'Normal priority' },
+              { name: 'type:import', color: '1D76DB', description: 'Repository import work' },
+              { name: 'type:hygiene', color: '0E8A16', description: 'Repository hygiene' },
+              { name: 'type:validation', color: '5319E7', description: 'Validation and CI work' },
+              { name: 'type:adapter', color: '0052CC', description: 'Adapter implementation work' },
+              { name: 'status:planned', color: 'A2EEEF', description: 'Planned backlog item' },
+            ];
+
+            const backlog = [
+              {
+                title: 'P0: Audit missing POC files under product/system/poc_with_triggers',
+                body: 'Create a definitive inventory of missing files versus documented architecture.\n\nAcceptance criteria:\n- Inventory grouped by module (core/media/adapter/tests/host setup).\n- Missing-file list checked into docs or posted in issue.',
+                labels: ['priority:P0', 'type:import', 'status:planned'],
+              },
+              {
+                title: 'P0: Import first safe POC batch with explicit placeholders',
+                body: 'Import the first substantial runnable code batch and keep unsupported/credential-dependent behavior behind explicit placeholders.\n\nAcceptance criteria:\n- First substantial batch present in repo.\n- Placeholders clearly marked.',
+                labels: ['priority:P0', 'type:import', 'status:planned'],
+              },
+              {
+                title: 'P1: Resolve test.txt artifact (remove or justify)',
+                body: 'Resolve the hygiene artifact by removing test.txt or documenting why it must remain.\n\nAcceptance criteria:\n- test.txt removed OR justification documented.',
+                labels: ['priority:P1', 'type:hygiene', 'status:planned'],
+              },
+              {
+                title: 'P1: Add/verify smoke tests and align CI with real paths',
+                body: 'Ensure smoke tests are present in-repo and CI references existing paths only.\n\nAcceptance criteria:\n- Smoke tests are runnable.\n- CI compile/smoke checks pass on real paths.',
+                labels: ['priority:P1', 'type:validation', 'status:planned'],
+              },
+              {
+                title: 'P2: Continue Webex adapter in small, controlled increments',
+                body: 'Continue Webex work only after import/hygiene/validation gates. Preserve dry-run support and shared-core boundaries.\n\nAcceptance criteria:\n- Dry-run remains functional.\n- send_audio path uses media worker contract.',
+                labels: ['priority:P2', 'type:adapter', 'status:planned'],
+              },
+            ];
+
+            async function ensureLabels() {
+              for (const label of labels) {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name: label.name });
+                  core.info(`Label exists: ${label.name}`);
+                } catch (err) {
+                  if (err.status === 404) {
+                    await github.rest.issues.createLabel({ owner, repo, ...label });
+                    core.info(`Created label: ${label.name}`);
+                  } else {
+                    throw err;
+                  }
+                }
+              }
+            }
+
+            async function findOrCreateIssue(item) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'all',
+                per_page: 100,
+              });
+
+              const existing = issues.find(i => i.title === item.title && !i.pull_request);
+              if (existing) {
+                core.info(`Issue exists: ${existing.html_url}`);
+                return existing;
+              }
+
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title: item.title,
+                body: item.body,
+                labels: item.labels,
+              });
+
+              core.info(`Created issue: ${created.data.html_url}`);
+              return created.data;
+            }
+
+            async function getProjectId() {
+              const query = `
+                query($owner: String!, $number: Int!) {
+                  user(login: $owner) {
+                    projectV2(number: $number) {
+                      id
+                    }
+                  }
+                }
+              `;
+
+              const result = await github.graphql(query, { owner, number: projectNumber });
+              const id = result?.user?.projectV2?.id;
+              if (!id) throw new Error(`Could not find project ${owner}/${projectNumber}`);
+              return id;
+            }
+
+
+            async function setProjectDescription(projectId) {
+              const mutation = `
+                mutation($projectId: ID!, $description: String!) {
+                  updateProjectV2(input: { projectId: $projectId, shortDescription: $description }) {
+                    projectV2 {
+                      id
+                      shortDescription
+                    }
+                  }
+                }
+              `;
+
+              await github.graphql(mutation, { projectId, description: projectDescription });
+              core.info('Updated project description.');
+            }
+
+            async function addIssueToProject(projectId, issueNodeId, issueUrl) {
+              const mutation = `
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                    item {
+                      id
+                    }
+                  }
+                }
+              `;
+
+              try {
+                await github.graphql(mutation, { projectId, contentId: issueNodeId });
+                core.info(`Added to project: ${issueUrl}`);
+              } catch (err) {
+                if (String(err.message).includes('already exists')) {
+                  core.info(`Already in project: ${issueUrl}`);
+                } else {
+                  throw err;
+                }
+              }
+            }
+
+            await ensureLabels();
+            const projectId = await getProjectId();
+            await setProjectDescription(projectId);
+
+            for (const item of backlog) {
+              const issue = await findOrCreateIssue(item);
+              await addIssueToProject(projectId, issue.node_id, issue.html_url);
+            }
+
+            core.info('Project seeding completed.');

--- a/docs/github-project-2-setup.md
+++ b/docs/github-project-2-setup.md
@@ -1,0 +1,59 @@
+# GitHub Project #2 Setup (Cloud-first)
+
+This repository now includes a **cloud workflow** so you do not need to run setup on your local machine.
+
+## Recommended path (no local setup)
+
+1. In GitHub, open this repository's **Settings → Secrets and variables → Actions**.
+2. Create a secret named `PROJECT_SETUP_TOKEN` with a PAT that has:
+   - `repo` scope (for issues/labels)
+   - `project` scope (for ProjectV2 item operations)
+3. Go to **Actions → Setup GitHub Project #2 → Run workflow**.
+4. Keep defaults (`owner=intiequals1`, `project_number=2`) and run.
+
+Workflow file: `.github/workflows/setup-project2.yml`.
+
+For CLI usage, you can override description text with `PROJECT_DESCRIPTION` when running `scripts/setup_github_project2.sh`.
+
+## What the cloud workflow does
+
+- Ensures baseline labels exist.
+- Finds or creates the baseline backlog issues (idempotent by exact title).
+- Adds each issue to `https://github.com/users/intiequals1/projects/2`.
+
+## Project description seeded
+
+- `Cross-platform AI Virtual User: shared AI core with platform adapters (Webex first), Linux host audio path, smoke tests, and CI baseline.`
+
+## Baseline issues seeded
+
+- P0: Audit missing POC files under `product/system/poc_with_triggers`
+- P0: Import first safe POC batch with explicit placeholders
+- P1: Resolve `test.txt` artifact (remove or justify)
+- P1: Add/verify smoke tests and align CI with real paths
+- P2: Continue Webex adapter in small, controlled increments
+
+## Notes
+
+- The workflow is idempotent for issue creation and project item add operations.
+- If your project owner is an org instead of a user, adjust the GraphQL lookup accordingly.
+
+## Make Project #2 accessible without sign-in
+
+If you want anyone (including unauthenticated environments) to view the board in the browser:
+
+1. Open `https://github.com/users/intiequals1/projects/2`.
+2. Click **...** (top-right) → **Settings**.
+3. Set **Visibility** to **Public**.
+4. Ensure the linked repository is also publicly readable (or viewers have read access), otherwise item content can still be restricted.
+
+### Important limitation
+
+- GitHub API/CLI operations that mutate project data (create items, update fields, etc.) still require authentication, even if the project is public.
+- Public visibility improves read access in the browser; it does not remove token requirements for automation writes.
+
+### Quick verification
+
+- Browser: open the project URL in a private/incognito window.
+- CLI (read check): `gh project view 2 --owner intiequals1`
+

--- a/scripts/setup_github_project2.sh
+++ b/scripts/setup_github_project2.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   OWNER=intiequals1 REPO=virtual-user-ai PROJECT_NUMBER=2 ./scripts/setup_github_project2.sh
+# Requirements:
+#   - gh installed and authenticated
+#   - access to the repository and user project
+
+OWNER="${OWNER:-intiequals1}"
+REPO="${REPO:-virtual-user-ai}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-2}"
+PROJECT_DESCRIPTION="${PROJECT_DESCRIPTION:-Cross-platform AI Virtual User: shared AI core with platform adapters (Webex first), Linux host audio path, smoke tests, and CI baseline.}"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+need gh
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "GitHub CLI is not authenticated. Run: gh auth login" >&2
+  exit 1
+fi
+
+REPO_REF="${OWNER}/${REPO}"
+PROJECT_REF="https://github.com/users/${OWNER}/projects/${PROJECT_NUMBER}"
+
+echo "Using repo: ${REPO_REF}"
+echo "Using project: ${PROJECT_REF}"
+
+echo "Ensuring labels exist..."
+for label in "priority:P0" "priority:P1" "priority:P2" "type:import" "type:hygiene" "type:validation" "type:adapter" "status:planned"; do
+  gh label create "$label" --repo "$REPO_REF" --color "1D76DB" --force >/dev/null
+  echo "  - $label"
+done
+
+create_issue() {
+  local title="$1"
+  local body="$2"
+  local labels="$3"
+  local out
+  out=$(gh issue create --repo "$REPO_REF" --title "$title" --body "$body" --label "$labels")
+  echo "$out"
+}
+
+get_project_id() {
+  gh api graphql \
+    -f query='query($owner:String!, $number:Int!) { user(login:$owner) { projectV2(number:$number) { id } } }' \
+    -F owner="$OWNER" \
+    -F number="$PROJECT_NUMBER" \
+    --jq '.data.user.projectV2.id'
+}
+
+set_project_description() {
+  local project_id="$1"
+
+  gh api graphql \
+    -f query='mutation($projectId:ID!, $description:String!) { updateProjectV2(input: {projectId: $projectId, shortDescription: $description}) { projectV2 { id shortDescription } } }' \
+    -F projectId="$project_id" \
+    -F description="$PROJECT_DESCRIPTION" \
+    >/dev/null
+
+  echo "Updated project description."
+}
+
+echo "Creating baseline issues..."
+ISSUE_URLS=()
+
+ISSUE_URLS+=("$(create_issue \
+  "P0: Audit missing POC files under product/system/poc_with_triggers" \
+  "Create a definitive inventory of missing files versus documented architecture.\n\nAcceptance criteria:\n- Inventory grouped by module (core/media/adapter/tests/host setup).\n- Missing-file list checked into docs or posted in issue." \
+  "priority:P0,type:import,status:planned")")
+
+ISSUE_URLS+=("$(create_issue \
+  "P0: Import first safe POC batch with explicit placeholders" \
+  "Import the first substantial runnable code batch and keep unsupported/credential-dependent behavior behind explicit placeholders.\n\nAcceptance criteria:\n- First substantial batch present in repo.\n- Placeholders clearly marked." \
+  "priority:P0,type:import,status:planned")")
+
+ISSUE_URLS+=("$(create_issue \
+  "P1: Resolve test.txt artifact (remove or justify)" \
+  "Resolve the hygiene artifact by removing test.txt or documenting why it must remain.\n\nAcceptance criteria:\n- test.txt removed OR justification documented." \
+  "priority:P1,type:hygiene,status:planned")")
+
+ISSUE_URLS+=("$(create_issue \
+  "P1: Add/verify smoke tests and align CI with real paths" \
+  "Ensure smoke tests are present in-repo and CI references existing paths only.\n\nAcceptance criteria:\n- Smoke tests are runnable.\n- CI compile/smoke checks pass on real paths." \
+  "priority:P1,type:validation,status:planned")")
+
+ISSUE_URLS+=("$(create_issue \
+  "P2: Continue Webex adapter in small, controlled increments" \
+  "Continue Webex work only after import/hygiene/validation gates. Preserve dry-run support and shared-core boundaries.\n\nAcceptance criteria:\n- Dry-run remains functional.\n- send_audio path uses media worker contract." \
+  "priority:P2,type:adapter,status:planned")")
+
+PROJECT_ID="$(get_project_id)"
+set_project_description "$PROJECT_ID"
+
+echo "Adding issues to project..."
+for url in "${ISSUE_URLS[@]}"; do
+  gh project item-add "$PROJECT_NUMBER" --owner "$OWNER" --url "$url" >/dev/null
+  echo "  - added $url"
+done
+
+echo "Done. Created and added ${#ISSUE_URLS[@]} issues to ${PROJECT_REF}."

--- a/tests/test_project2_setup.py
+++ b/tests/test_project2_setup.py
@@ -1,0 +1,66 @@
+import unittest
+from pathlib import Path
+
+
+class TestProject2SetupAssets(unittest.TestCase):
+    def setUp(self):
+        self.workflow = Path('.github/workflows/setup-project2.yml')
+        self.script = Path('scripts/setup_github_project2.sh')
+        self.docs = Path('docs/github-project-2-setup.md')
+
+    def test_files_exist(self):
+        self.assertTrue(self.workflow.exists(), 'workflow file missing')
+        self.assertTrue(self.script.exists(), 'setup script missing')
+        self.assertTrue(self.docs.exists(), 'setup docs missing')
+
+    def test_workflow_contains_required_cloud_setup_hooks(self):
+        text = self.workflow.read_text(encoding='utf-8')
+        required_fragments = [
+            'workflow_dispatch',
+            'PROJECT_SETUP_TOKEN',
+            'actions/github-script@v7',
+            'addProjectV2ItemById',
+            'project_number',
+            'updateProjectV2',
+            'priority:P0',
+            'P0: Audit missing POC files under product/system/poc_with_triggers',
+        ]
+        for fragment in required_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, text)
+
+    def test_cli_script_contains_required_steps(self):
+        text = self.script.read_text(encoding='utf-8')
+        required_fragments = [
+            'set -euo pipefail',
+            'need gh',
+            'gh auth status',
+            'gh issue create',
+            'gh project item-add',
+            'updateProjectV2',
+            'PROJECT_DESCRIPTION',
+            'priority:P0',
+            'status:planned',
+        ]
+        for fragment in required_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, text)
+
+    def test_docs_cover_cloud_setup_and_accessibility(self):
+        text = self.docs.read_text(encoding='utf-8')
+        required_fragments = [
+            'Recommended path (no local setup)',
+            'PROJECT_SETUP_TOKEN',
+            'Project description seeded',
+            'Make Project #2 accessible without sign-in',
+            'Visibility',
+            'Public',
+            'Quick verification',
+        ]
+        for fragment in required_fragments:
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, text)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide an automated, idempotent way to seed and maintain baseline labels, backlog issues, and ProjectV2 items for Project #2 via cloud and CLI paths.
- Document the operational steps and token requirements so maintainers can run the setup without local ad-hoc scripts.

### Description

- Add a GitHub Actions workflow (`.github/workflows/setup-project2.yml`) that uses `actions/github-script@v7` to ensure labels, create or find baseline issues, update the project description with `updateProjectV2`, and add items to the project via `addProjectV2ItemById`. 
- Add a CLI helper script (`scripts/setup_github_project2.sh`) that uses the `gh` CLI to perform the same operations locally and supports environment overrides for `OWNER`, `REPO`, `PROJECT_NUMBER`, and `PROJECT_DESCRIPTION`. 
- Add documentation (`docs/github-project-2-setup.md`) describing cloud-first usage, token/scopes required (`PROJECT_SETUP_TOKEN`), seeded project description, seeded backlog items, and visibility/access notes. 
- Add unit tests (`tests/test_project2_setup.py`) that validate the presence of the workflow, script, and docs and assert they contain required fragments for the cloud/CLI setup and seeded content. 

### Testing

- Ran the new unit tests with `python -m unittest tests/test_project2_setup.py`, and they passed. 
- Verified the workflow contains required GraphQL operations and that the CLI script contains the expected `gh` commands via the added tests, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38b4fdafc832d9dda65586ac7798a)