### PR TITLE
Add script to scaffold a new repository

### DIFF
--- a/scripts/create_new_repo.sh
+++ b/scripts/create_new_repo.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <repo-name> [target-directory]" >&2
+  exit 1
+fi
+
+repo_name="$1"
+target_dir="${2:-.}"
+repo_path="${target_dir%/}/${repo_name}"
+
+if [[ -e "$repo_path" ]]; then
+  echo "Error: path already exists: $repo_path" >&2
+  exit 1
+fi
+
+mkdir -p "$repo_path"
+cd "$repo_path"
+
+git init -b main >/dev/null
+cat > README.md <<EOT
+# ${repo_name}
+
+Dieses Repository wurde mit \`scripts/create_new_repo.sh\` erstellt.
+EOT
+
+cat > .gitignore <<'EOT'
+# Python
+__pycache__/
+*.py[cod]
+
+# Environment
+.env
+.venv/
+
+# OS
+.DS_Store
+Thumbs.db
+EOT
+
+git add README.md .gitignore
+git commit -m "Initial commit" >/dev/null
+
+echo "Neues Repository erstellt: $repo_path"


### PR DESCRIPTION
### Motivation
- Provide a small helper to quickly scaffold a new Git repository with sensible starter files to streamline project creation.

### Description
- Add `scripts/create_new_repo.sh`, an executable script that creates a new directory, initializes a repository, writes a starter `README.md` and `.gitignore`, stages the starter files, and reports the created path.

### Testing
- Verified script syntax with `bash -n scripts/create_new_repo.sh` and exercised the scaffolding by running `./scripts/create_new_repo.sh neues-repo /workspace`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00a0d35a4832dbc3888e3a8d2f6e2)